### PR TITLE
clarify sync problem, copyediting on 2.1.1

### DIFF
--- a/2.1.1.ConnectionSetup.md
+++ b/2.1.1.ConnectionSetup.md
@@ -1,4 +1,4 @@
-# Connection Setup 
+# Connection Setup
 - [Connection Setup](#connection-setup)
   - [Abstract](#abstract)
   - [1. Introduction](#1-introduction)
@@ -35,7 +35,7 @@
 <summary> Introduction </summary>
 In the context of quantum networking and internet, connection setup refers to the process of establishing a connection between two or more end nodes in a quantum network. This task is crucial because it allows for the transfer of quantum information and enables various quantum communication protocols.
 
-To ensure reliable and efficient quantum communication, network nodes need to manage and allocate the available entanglement resources effectively especially for near-term quantum network that is extremely fragile to the noise and loss. 
+To ensure reliable and efficient quantum communication, network nodes need to manage and allocate the available entanglement resources effectively especially for near-term quantum network that is extremely fragile to the noise and loss.
 
 </details>
 
@@ -59,7 +59,7 @@ Multiple qubits (mainly two qubits in this document) state are entangled means t
 
 **Entanglement Swapping**
 
-Entanglement swapping is a technique that teleports entanglement and get a longer entangled state by consuming two relatively shorter entangled states. 
+Entanglement swapping is a technique that teleports entanglement and get a longer entangled state by consuming two relatively shorter entangled states.
 
 **Fidelity**
 
@@ -78,7 +78,7 @@ The *initiator* is an end node quantum computer that demands quantum network and
 ### 3.1 Quantum Recursive Network Architecture
 > Should this be instroduced here?
 
-Quantum Recursive Network Architecture (QRNA) [^VAN2011] is a quantum network architecture inspired by a Recursive Network Architecture (RNA) [^TOU2008]. QRNA assumes the existence of layers that support a unified meta protocol which can be used to define quantum network protocols in different layers. 
+Quantum Recursive Network Architecture (QRNA) [^VAN2011] is a quantum network architecture inspired by a Recursive Network Architecture (RNA) [^TOU2008]. QRNA assumes the existence of layers that support a unified meta protocol which can be used to define quantum network protocols in different layers.
 QRNA allows hiding complex lower layer network topologies from higher topologies.
 > Add explanation
 
@@ -141,7 +141,7 @@ sequenceDiagram
         Responder ->> Repeater N: Ack / RuleSet
         Note over Repeater N, Responder: Link Allocation Update
         Note over Repeater N, Responder: RuleSet Execution Start
-        
+
         Responder ->> ...: Ack / RuleSet
         Note over ..., Repeater N: Link Allocation Update
         Note over ..., Repeater N: RuleSet Execution Start
@@ -174,12 +174,12 @@ sequenceDiagram
     autonumber
     %% Participants in the path
     participant i1 as Initiator 1
-    participant i2 as Initiator 2 
+    participant i2 as Initiator 2
     box Orange EPPS Link
     participant ra as Repeater A
     participant epps as EPPS
     participant rb as Repeater B
-    end 
+    end
     participant r2 as Responder 2
     participant r1 as Responder 1
 
@@ -190,12 +190,12 @@ sequenceDiagram
     %% Keep generating Bell pairs
     epps -->> ra: Photon 239
     epps -->> rb: Photon 239
-    
+
     r2 ->> rb: RuleSet 2 (cid = 2)
     r2 ->> ra: RuleSet 2 (cid = 2)
     rb ->> ra: LAU (Link Allocation Update)
     ra ->> rb: LAU (Link Allocation Update)
-    
+
     epps -->> ra: Photon 240
     epps -->> rb: Photon 240
 
@@ -247,7 +247,7 @@ sequenceDiagram
     end
     Note over routa: Store local info
 
-    routa ->> routb: CSR 
+    routa ->> routb: CSR
     Note over routb: Stack local info
     routb ->> repb: CSR
     Note over repb: Stack local info
@@ -271,11 +271,11 @@ sequenceDiagram
     routa ->> routa: Ack/RuleSet
     Note over routa, routb: LAU
     Note over routa, routb: RuleSet Execution Start
-    
+
     routa ->> repa: Ack/RuleSet
     Note over routa, repa: LAU
     Note over routa, repa: RuleSet Execution Start
-    
+
     routa ->> ini: Ack/RuleSet
     Note over ini, repa: LAU
     Note over ini, repa: RuleSet Execution Start
@@ -305,7 +305,7 @@ sequenceDiagram
 
     Repeater A ->> Repeater B: Connection Setup Request
     Note over Repeater B: Availability Check (No)
-    
+
     Repeater B ->> Repeater A: Connection Reject Response
     Note over Repeater A: Release Connection Information
 
@@ -333,7 +333,7 @@ At the end of the RuleSet execution, both end nodes have to properly terminate t
 ```mermaid
 sequenceDiagram
     autonumber
-    participant ini as Initiator 
+    participant ini as Initiator
     participant ra as Repeater A
     participant rb as Repeater B
     participant res as Responder
@@ -348,7 +348,7 @@ sequenceDiagram
     deactivate ini
     Note over res: Terminate RuleSet
     deactivate res
-    
+
     ini ->> ra: RuleSet Termination
     res ->> rb: RuleSet Termination
     ini ->> rb: RuleSet Termination
@@ -360,8 +360,8 @@ sequenceDiagram
     deactivate ra
 ```
 
-When multiple connections are sharing the same link, the link allocation policy must properly transit from `k` to `k-1` connections.
-The following diagram shows the transit from two connections to one connection.
+When multiple connections are sharing the same link, the link allocation policy must properly transition from `k` to `k-1` connections.
+The following diagram shows the transition from two connections to one connection.
 
 ```mermaid
 sequenceDiagram
@@ -369,7 +369,7 @@ sequenceDiagram
     %% Participants in the path
     participant i1 as Initiator 1
     participant i2 as Initiator 2
-    Box Orange Repeaters 
+    Box Orange Repeaters
     participant ra as Repeater A
     participant epps as EPPS
     participant rb as Repeater B
@@ -383,12 +383,12 @@ sequenceDiagram
     %% Connection between initiator and responder
     i1 --> r1: Connection 1 (cid = 1)
     i2 --> r2: Connection 2 (cid = 2)
-    
+
 
     %% Keep generating Bell pairs
     epps -->> ra: Photon 239
     epps -->> rb: Photon 239
-    
+
     %% Start Termination
     Note over r2: Terminate RuleSet
     deactivate r2
@@ -402,7 +402,7 @@ sequenceDiagram
     i2 ->> rb: RuleSet Termination (cid = 2)
     rb ->> ra: LAU (Link Allocation Update)
     ra ->> rb: LAU (Link Allocation Update)
-    
+
     epps -->> ra: Photon 240
     epps -->> rb: Photon 240
 
@@ -441,16 +441,16 @@ A minimum requirements for the link-level entanglement generation performance su
 ### 6.2 Quantum Capability (QCap)
 > Do we need this?
 - Entanglement Generation Rate
-The gentanglement eneration rate is quite important for users to accomplish the application. 
+The gentanglement eneration rate is quite important for users to accomplish the application.
 
 - The threshold fidelity of link entanglement
 Is this suppose to be checked before routing?
-The fidelity is also a key factor for the realiable application. 
+The fidelity is also a key factor for the realiable application.
 
 - Time requirement
 
 - The number of end to end entanglement
-Quantum Application Client should know about how many Bell pairs (or other entangled states) do the initiator need to get the application done. 
+Quantum Application Client should know about how many Bell pairs (or other entangled states) do the initiator need to get the application done.
 
 ### 6.3 Connection Setup Reject
 - Reason code
@@ -460,7 +460,7 @@ This tell the initiator when the link would be available (What if there are mult
 
 
 ### 6.4 Connection Setup Response
-The responder needs to tell the initiator the request arrival to start entanglement generation and consumption. 
+The responder needs to tell the initiator the request arrival to start entanglement generation and consumption.
 
 - RuleSet
 - Path Information
@@ -472,21 +472,24 @@ The responder needs to tell the initiator the request arrival to start entanglem
 > Describe connection teardown request contents
 
 ### 6.6 RuleSet
-A RuleSet contains a set of rules that tells what to do for quantum repeaters. One RuleSet is composed of meta data and a set of stages that contains a set of rules.
+A RuleSet contains a set of rules that tells quantum network nodes what to do. One RuleSet is composed of metadata and a set of stages that contains a set of rules.
+> where are RuleSets defined? Reference that here.
 
 ### 6.7 Link Allocation Update (LAU)
-When a new connection is added or eliminated from the network, the resource allocation way might be changed. For example, in the case the two connections are competing one single link, the resource might be evenly distributed or distributed based on some algorithms. After one of two connection is done its entanglement genration, all the resource go into the remaining connection. During this transition, the link must properly know the allocation rule is changed and must be shared with neighboring node to keeep the consistency of the resource allocation. The worst case is that allocating one side of the resource to one connection and allocating the other side of the resurce to another connection.
+When a new connection is added or eliminated from the network, the resource allocation might be changed. For example, in the case where two connections are competing for the use of one single link, the resources might be evenly distributed or distributed based on some algorithm. After one of the two connections has completed its entanglement generation, all of the resources are shifted into the remaining connection. During this transition, the link must properly recognize that the allocation rule has changed and this change must be shared with the neighboring node to maintain the consistency of the resource allocation.
 
-LAU contains following information.
+If this link allocation (LA) transition is handled improperly, communications can be disrupted for all connections sharing the link. The scenario to be avoided is inconsistent allocation of resources at the two ends of the link.
+A problem occurs if one link end allocates its share of the resource to one connection while the other end of the link allocates its share of the resource to another connection. In this case, the two RuleSets operating at the two link ends will have inconsistent views of the set of available resources, and will make inconsistent decisions that result in failure to create the E2E resources properly. In the worst case, all connections passing through the link can fail: if one end allocates resources to connections A, B and C in the sequence ABABABCABCAB as connection C starts, but the other end allocates in the sequence ABABAABCABCA, then all subsequently generated resources will be allocated improperly and all three connections will fail. Recovery from this failure will be difficult.
+
+LAU contains the following information.
 
 - Terminating Connection Info
 Quantum repeaters at both ends agree with which connection is terminated
 - Allocation start info
-From remaining connection, repeaters have to choose which connection they allocate the next resource 
+From remaining connection, repeaters have to choose which connection they allocate the next resource
 
-### 6.7 Barrier
-> from rdv slack
->Barrier specifies the time at which the link switches from the current Link Allocation (LA) to the negotiated LA. It must come after the negotiation for the new LA is complete. For MSM links, as shown in the previous diagram, the Barrier value is the Photon Pair Trial Sequence Number (PPTSN) for the link. The PPTSN is defined by the EPPS. For MIM links, the PPTSN is defined by the BSA. For MM links, for consistency, it should be defined by the receiving end.
+### 6.8 Barrier
+Barrier specifies the time at which the link switches from the current Link Allocation (LA) to the negotiated LA. It must come after the negotiation for the new LA is complete. For MSM links, as shown in the previous diagram, the Barrier value is the Photon Pair Trial Sequence Number (PPTSN) for the link. The PPTSN is defined by the EPPS. For MIM links, the PPTSN is defined by the BSA. For MM links, for consistency, it should be defined by the receiving end.
 
 
 ### 7. Conclusion

--- a/2.1.1.ConnectionSetup.md
+++ b/2.1.1.ConnectionSetup.md
@@ -498,7 +498,7 @@ Barrier specifies the time at which the link switches from the current Link Allo
 ## Reference
 [^VAN2013]: Van Meter, Rodney, et al. "Path selection for quantum repeater networks." Networking Science 3 (2013): 82-95.
 
-[^VAN2011]: Van Meter, Rodney, Joe Touch, and Clare Horsman. "Recursive quantum repeater networks." arXiv preprint arXiv:1105.1238 (2011).
+[^VAN2011]: Van Meter, Rodney, Joe Touch, and D. Horsman. "Recursive quantum repeater networks." arXiv preprint arXiv:1105.1238 (2011).
 
 [^TOU2008]: Touch, Joseph D., and Venkata K. Pingali. "The RNA metaprotocol." 2008 Proceedings of 17th International Conference on Computer Communications and Networks. IEEE, 2008.
 


### PR DESCRIPTION
Actually a little bit more than just copyediting, but no technical changes, just added a clearer description of the link sync problem.